### PR TITLE
Foreign key fixes

### DIFF
--- a/lib/sqlutil.js
+++ b/lib/sqlutil.js
@@ -76,6 +76,24 @@ export class Db {
     });
   }
 
+  exec(sql) {
+    const self = this;
+    return new Promise((resolve, reject) => {
+      self.db.exec(sql, function (err, ...results) {
+        if (err) {
+          reject(new Error(`${err.message}, when running ${sql}`));
+        }
+        else {
+          // this is the statement object and contains lastID and changes
+          // which contain the value of the last inserted row ID (if the sql
+          // was an insert statement) and the number of rows affected by this
+          // query respectively.
+          resolve(this, ...results);
+        }
+      });
+    });
+  }
+
   get(sql, params) {
     if (!params) {
       params = [];

--- a/lib/sqlutil.js
+++ b/lib/sqlutil.js
@@ -8,9 +8,11 @@ export const DataType = {
   INTEGER: 'INTEGER',
   BOOLEAN: 'INTEGER',
   DATE: 'INTEGER',
+  NUMERIC: 'NUMERIC',
   TEXT: 'TEXT',
   FLOAT: 'REAL',
-  REAL: 'REAL'
+  REAL: 'REAL',
+  BLOB: 'BLOB'
 };
 
 // sqlite3.verbose();

--- a/lib/sqlutil.js
+++ b/lib/sqlutil.js
@@ -176,6 +176,11 @@ export class Db {
 
     return this.run(`PRAGMA foreign_keys = ${enable}`);
   }
+
+  isForeignKeysEnabled() {
+    return this.get('PRAGMA foreign_keys')
+      .then(foreignKeysEnabled => Boolean(foreignKeysEnabled.foreign_keys));
+  }
 }
 
 
@@ -946,7 +951,11 @@ export class Table {
   }
 
   createOrUpdateTable() {
-    return this.tableExists().then(exists => {
+    return Promise.join(this.tableExists(), this.db.isForeignKeysEnabled(), (exists, foreignKeysEnabled) => {
+      if (foreignKeysEnabled) {
+        throw new Error('Foreign keys must be disabled when using createOrUpdateTable');
+      }
+
       if (exists) {
         return this.getSchemaFromDatabase().then(oldSchema => {
           if (!this._schemaMatchesDatabase(oldSchema)) {

--- a/lib/sqlutil.js
+++ b/lib/sqlutil.js
@@ -166,8 +166,15 @@ export class Db {
     });
   }
 
-  enableForeignKeys() {
-    return this.run('PRAGMA foreign_keys = ON');
+  enableForeignKeys(enable) {
+    if (enable === undefined) {
+      enable = 'ON';
+    }
+    else if (!enable) {
+      enable = 'OFF';
+    }
+
+    return this.run(`PRAGMA foreign_keys = ${enable}`);
   }
 }
 

--- a/lib/sqlutil.js
+++ b/lib/sqlutil.js
@@ -981,8 +981,13 @@ export class Table {
             let fieldsInBoth = _.intersection(Object.keys(oldSchema.columns), Object.keys(this.schema.columns));
             let joinedFiledsInBoth = fieldsInBoth.join(', ');
 
-            let sql = `BEGIN TRANSACTION;\nALTER TABLE ${this.schema.name} RENAME TO ${backupTableName};\n${this._createTableSql()};\nINSERT INTO ${this.schema.name} (${joinedFiledsInBoth}) SELECT ${joinedFiledsInBoth} FROM ${backupTableName}\n;DROP TABLE ${backupTableName};\nCOMMIT;\n`;
-            return this.db.run(sql)
+            let sql = `BEGIN TRANSACTION;\n`
+              + `ALTER TABLE ${this.schema.name} RENAME TO ${backupTableName};\n`
+              + `${this._createTableSql()}\n`
+              + `INSERT INTO ${this.schema.name} (${joinedFiledsInBoth}) SELECT ${joinedFiledsInBoth} FROM ${backupTableName};\n`
+              + `DROP TABLE ${backupTableName};\n`
+              + `COMMIT;\n`;
+            return this.db.exec(sql)
               .then(() => {
                 return {wasCreated: false, wasUpdated: true};
               });

--- a/lib/sqlutil.js
+++ b/lib/sqlutil.js
@@ -945,7 +945,7 @@ export class Table {
   // Create table
   createTable() {
     return Promise.try(() => {
-      let sql = `${this._createTableSql()};`;
+      let sql = `${this._createTableSql()}`;
       return this.db.run(sql);
     });
   }

--- a/lib/sqlutil.js
+++ b/lib/sqlutil.js
@@ -945,6 +945,33 @@ export class Table {
     });
   }
 
+  createOrUpdateTable() {
+    return this.tableExists().then(exists => {
+      if (exists) {
+        return this.getSchemaFromDatabase().then(oldSchema => {
+          if (!this._schemaMatchesDatabase(oldSchema)) {
+            let backupTableName = `backup_${this.schema.name}_${Date.now()}`;
+            let fieldsInBoth = _.intersection(Object.keys(oldSchema.columns), Object.keys(this.schema.columns));
+            let joinedFiledsInBoth = fieldsInBoth.join(', ');
+
+            let sql = `BEGIN TRANSACTION;\nALTER TABLE ${this.schema.name} RENAME TO ${backupTableName};\n${this._createTableSql()};\nINSERT INTO ${this.schema.name} (${joinedFiledsInBoth}) SELECT ${joinedFiledsInBoth} FROM ${backupTableName}\n;DROP TABLE ${backupTableName};\nCOMMIT;\n`;
+            return this.db.run(sql)
+              .then(() => {
+                return {wasCreated: false, wasUpdated: true};
+              });
+          }
+
+          return {wasCreated: false, wasUpdated: false};
+        });
+      }
+
+      return this.createTable()
+        .then(() => {
+          return {wasCreated: true};
+        });
+    });
+  }
+
   _createTableSql() {
     let indices = this.schema.indices || {};
 

--- a/lib/sqlutil.js
+++ b/lib/sqlutil.js
@@ -1035,45 +1035,44 @@ export class Table {
     return this.db.get(sql).then(field => Boolean(field));
   }
 
-  /** Check if the schema matches the structure in the database */
-  schemaMatchesDatabase() {
-    let columnsHaveChanged = () => {
-      let sql = `PRAGMA TABLE_INFO(${this.schema.name})`;
-      return this.db.all(sql).then(oldColumns => {
-        let namedOldColumns = _.keyBy(oldColumns, 'name');
-        let columnsInBoth = _.intersection(Object.keys(this.schema.columns), Object.keys(namedOldColumns));
-
-        // Check if there are any changes to the columns.
-        let recreateTable = (columnsInBoth.length !== oldColumns.length)
-            || (columnsInBoth.length !== Object.keys(this.schema.columns).length);
-
-        if (!recreateTable) {
-          // Check if the types and column parameters match
-          recreateTable = columnsInBoth.map(columnName => {
-            let thisColumn = this.schema.columns[columnName];
-            let oldColumn = namedOldColumns[columnName];
-
-            let thisNotNull = Boolean(thisColumn.notNull)
-                && !thisColumn.primaryKey;
-
-            let thisDefaultValue = null;
-            if (_.isString(thisColumn.defaultValue)) {
-              thisDefaultValue = `"${thisColumn.defaultValue}"`;
-            }
-            else if (!_.isUndefined(thisColumn.defaultValue)) {
-              thisDefaultValue = thisColumn.defaultValue;
-            }
-
+  getSchemaFromDatabase() {
+    let columnsPromise = this.db.all(`PRAGMA TABLE_INFO(${this.schema.name})`)
+        .then(sqlColumns => {
+          let namedColumns = _.keyBy(sqlColumns, 'name');
+          let columns = {};
+          _.forEach(namedColumns, (column, name) => {
             // Note: oldcolumn.notnull is the name from the pragma query, it is
             // not camelcased and returned as an interger (0 or 1)
-            let oldNotNull = Boolean(oldColumn.notnull);
+            let notNull = Boolean(column.notnull);
 
-            // TODO: Better type conversions for oldDefaultValue
-            let oldDefaultValue = oldColumn.dflt_value;
-            if (oldDefaultValue) {
-              switch (oldColumn.type) {
+            let type;
+            switch (column.type) {
+              case 'INTEGER':
+                type = DataType.INTEGER;
+                break;
+
+              case 'NUMERIC':
+                type = DataType.NUMERIC;
+                break;
+
+              case 'TEXT':
+                type = DataType.TEXT;
+                break;
+
+              case 'REAL':
+                type = DataType.FLOAT;
+                break;
+
+              default:
+                type = 'BLOB';
+            }
+
+            // TODO: Better type conversions for defaultValue
+            let defaultValue = column.dflt_value;
+            if (defaultValue) {
+              switch (column.type) {
                 case 'INTEGER':
-                  oldDefaultValue = Number.parseInt(oldDefaultValue, 10);
+                  defaultValue = Number.parseInt(defaultValue, 10);
                   break;
 
                 default:
@@ -1081,55 +1080,109 @@ export class Table {
               }
             }
 
-            return ((thisColumn.type !== oldColumn.type)
-                    || (thisNotNull !== oldNotNull)
-                    || (thisDefaultValue !== oldDefaultValue));
-          }).reduce((x, y) => x || y, false);
-        }
-
-        return recreateTable;
-      });
-    };
-
-    let foreignKeysHaveChanged = () => {
-      let sql = `PRAGMA foreign_key_list(${this.schema.name})`;
-      return this.db.all(sql).then(oldForeignKeys => {
-        let foreignKeys = this.schema.foreignKeys || [];
-        let recreateTable = (oldForeignKeys.length !== foreignKeys.length);
-
-        // Check if the foreign key from/references have changed
-        for (let i = 0; i < oldForeignKeys.length; i++) {
-          let oldForeignKey = oldForeignKeys[i];
-          // Find matching new foreign key
-          let newForeignKey = _.find(foreignKeys, foreignKey => {
-            return foreignKey.from === oldForeignKey.from;
+            columns[name] = {
+              type,
+              notNull,
+              defaultValue
+            };
           });
 
-          recreateTable = recreateTable || !newForeignKey
-            || !_.has(newForeignKey.references, oldForeignKey.table)
-            || newForeignKey.references[oldForeignKey.table] !== oldForeignKey.to;
-        }
+          return columns;
+        });
 
-        for (let i = 0; i < foreignKeys.length; i++) {
-          let newForeignKey = foreignKeys[i];
-          let oldForeignKey = _.find(oldForeignKeys, foreignKey => {
-            return foreignKey.from === newForeignKey.from;
+    let foreignKeysPromise
+        = this.db.all(`PRAGMA foreign_key_list(${this.schema.name})`)
+        .then(foreignKeys => {
+          return foreignKeys.map(foreignKey => {
+            return {
+              from: foreignKey.from,
+              references: {[foreignKey.table]: foreignKey.to}
+            };
           });
+        });
 
-          recreateTable = recreateTable || !oldForeignKey
-            || !_.has(newForeignKey.references, oldForeignKey.table)
-            || newForeignKey.references[oldForeignKey.table] !== oldForeignKey.to;
-        }
+    return Promise.join(columnsPromise, foreignKeysPromise, (columns, foreignKeys) => {
+      return {
+        name: this.schema.name,
+        columns,
+        foreignKeys
+      };
+    });
+  }
 
-        return recreateTable;
-      });
-    };
+  _schemaMatchesDatabase(oldSchema) {
+    function columnIsNotNull(column) {
+      return Boolean(column.notNull) && !column.primaryKey;
+    }
+    function columnDefaultValue(column) {
+      let defaultValue = null;
+      if (_.isString(column.defaultValue)) {
+        defaultValue = `"${column.defaultValue}"`;
+      }
+      else if (!_.isUndefined(column.defaultValue)) {
+        defaultValue = column.defaultValue;
+      }
+      return defaultValue;
+    }
+    function foreignKeyReferences(foreignKey) {
+      if (!foreignKey) {
+        return undefined;
+      }
 
-    // Check if the columns or foreign keys have changed
-    return Promise.join(columnsHaveChanged(), foreignKeysHaveChanged(),
-      (recreate1, recreate2) => {
-        return !(recreate1 || recreate2);
-      });
+      let oldReferencesKeys = Object.keys(foreignKey.references);
+      assert(oldReferencesKeys.length === 1);
+
+      let table = oldReferencesKeys[0];
+      let field = foreignKey.references[table];
+      return {table, field};
+    }
+
+    let columnsInBoth = _.intersection(Object.keys(this.schema.columns), Object.keys(oldSchema.columns));
+
+    // Check if there are any changes to the columns.
+    let schemasAreEqual = (columnsInBoth.length === Object.keys(oldSchema.columns).length)
+        && (columnsInBoth.length === Object.keys(this.schema.columns).length);
+    if (schemasAreEqual) {
+      // Check if the types and column parameters match
+      schemasAreEqual = columnsInBoth.map(columnName => {
+        let thisColumn = this.schema.columns[columnName];
+        let oldColumn = oldSchema.columns[columnName];
+
+        return ((thisColumn.type === oldColumn.type)
+                && columnIsNotNull(thisColumn) === columnIsNotNull(oldColumn)
+                && columnDefaultValue(thisColumn) === columnDefaultValue(oldColumn));
+      }).reduce((x, y) => x && y, true);
+    }
+
+    // Check if there are any changes to the foreign keys
+    if (schemasAreEqual) {
+      let oldForeignKeys = oldSchema.foreignKeys || [];
+      let foreignKeys = this.schema.foreignKeys || [];
+      schemasAreEqual = (oldForeignKeys.length === foreignKeys.length);
+
+      // Check if the foreign key from/references have changed
+      for (let i = 0; i < oldForeignKeys.length; i++) {
+        let oldForeignKey = oldForeignKeys[i];
+        let newForeignKey = _.find(foreignKeys, foreignKey => {
+          return foreignKey.from === oldForeignKey.from;
+        });
+
+        let oldReferences = foreignKeyReferences(oldForeignKey);
+        let newReferences = foreignKeyReferences(newForeignKey);
+
+        schemasAreEqual = schemasAreEqual && (newForeignKey !== null)
+          && (oldReferences.table === newReferences.table)
+          && (oldReferences.field === newReferences.field);
+      }
+    }
+
+    return schemasAreEqual;
+  }
+
+  /** Check if the schema matches the structure in the database */
+  schemaMatchesDatabase() {
+    return this.getSchemaFromDatabase()
+      .then(oldSchema => this._schemaMatchesDatabase(oldSchema));
   }
 
   createWriteStream(options = {}) {

--- a/lib/sqlutil.js
+++ b/lib/sqlutil.js
@@ -1080,9 +1080,9 @@ export class Table {
           }
         });
 
-        let unique = index.unique ? 'UNIQUE' : '';
+        let unique = index.unique ? 'UNIQUE ' : '';
         let columnListing = index.columns.join(',');
-        return `CREATE ${unique} INDEX IF NOT EXISTS ix_${this.schema.name}_${indexName} ON ${this.schema.name} (${columnListing});`;
+        return `CREATE ${unique}INDEX IF NOT EXISTS ix_${this.schema.name}_${indexName} ON ${this.schema.name} (${columnListing});`;
       }));
     }
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "repository": "erikman/sqlutil",
   "devDependencies": {
     "babel-cli": "^6.24.1",
-    "babel-core": "^6.22.1",
+    "babel-core": "^6.26.0",
     "babel-eslint": "^7.1.1",
     "babel-preset-env": "^1.6.0",
     "babel-preset-stage-2": "^6.22.0",

--- a/test/foreignkeys_test.js
+++ b/test/foreignkeys_test.js
@@ -45,6 +45,14 @@ describe('table with foreign keys', () => {
       .then(() => childTable.insert({parentId: 1, value: 'Ape'}));
   }
 
+  it('should be possible to enable support for foreign keys', () => {
+    return expect(db.isForeignKeysEnabled(), 'initially disabled').to.eventually.equal(false)
+      .then(() => db.enableForeignKeys())
+      .then(() => expect(db.isForeignKeysEnabled(), 'enabled after requested').to.eventually.equal(true))
+      .then(() => db.enableForeignKeys(false))
+      .then(() => expect(db.isForeignKeysEnabled(), 'disabled after requested').to.eventually.equal(false));
+  });
+
   it('should be possible to insert valid rows', () => {
     return db.enableForeignKeys().then(() => insertSomeData());
   });

--- a/test/foreignkeys_test.js
+++ b/test/foreignkeys_test.js
@@ -62,10 +62,16 @@ describe('table with foreign keys', () => {
       .to.eventually.be.fulfilled;
   });
 
-  it('should not be possible to insert foreign key validations when foreign keys are enabled', () => {
+  it('should not be possible to insert invalid foreign keys when foreign keys are enabled', () => {
     return db.enableForeignKeys().then(() => {
-      return expect(childTable.insert({parentId: 42, value: 'Ape'})).to.eventually.be.rejectedWith(/FOREIGN KEY constraint failed/);
+      return expect(childTable.insert({parentId: 42, value: 'Ape'}))
+        .to.eventually.be.rejectedWith(/FOREIGN KEY constraint failed/);
     });
+  });
+
+  it('should not be possible to update table when foreign keys are enabled', () => {
+    return db.enableForeignKeys()
+      .then(() => expect(childTable.createOrUpdateTable()).to.eventually.be.rejected);
   });
 
   it('should be possible to remove foreign keys from a table', () => {
@@ -143,6 +149,8 @@ describe('table with foreign keys', () => {
       .then(() => expect(newParentTable.createOrUpdateTable())
             .to.eventually.deep.equal({wasCreated: false, wasUpdated: true}))
       .then(() => expect(newParentTable.find({name: 'Banan'}).get())
-            .to.eventually.deep.equal({id: 1, name: 'Banan'}));
+            .to.eventually.deep.equal({id: 1, name: 'Banan', value: 3}))
+      .then(() => expect(childTable.find({value: 'Apa'}).get())
+            .to.eventually.deep.equal({id: 1, value: 'Apa', parentId: 1}));
   });
 });

--- a/test/sqlutil.js
+++ b/test/sqlutil.js
@@ -12,16 +12,14 @@ let expect = chai.expect;
 describe('sqlutil', () => {
   let db;
 
-  describe('table', () => {
-    let table;
-
+  describe('basic operations', () => {
     it('should be able to create a database in memory', () => {
       db = new sqlutil.Db();
       return db.open(':memory:');
     });
 
     it('should be possible to create new tables', () => {
-      table = new sqlutil.Table(db, {
+      let table = new sqlutil.Table(db, {
         name: 'testtable',
         columns: {
           id: {type: sqlutil.DataType.INTEGER, primaryKey: true},
@@ -32,6 +30,32 @@ describe('sqlutil', () => {
 
       return table.createTable();
     });
+  });
+
+  describe('table', () => {
+    let table;
+
+    beforeEach(() => {
+      db = new sqlutil.Db();
+
+      table = new sqlutil.Table(db, {
+        name: 'testtable',
+        columns: {
+          id: {type: sqlutil.DataType.INTEGER, primaryKey: true},
+          name: {type: sqlutil.DataType.TEXT, unique: true},
+          value: {type: sqlutil.DataType.FLOAT}
+        }
+      });
+
+      return db.open(':memory:')
+        .then(() => table.createTable());
+    });
+
+    function insertSomeData() {
+      return table.insert({name: 'key1', value: 42})
+        .then(() => table.insert({name: 'key2', value: 42}))
+        .then(() => table.insert({name: 'key3', value: 43}));
+    }
 
     it('should not be possible to create an existing table', () => {
       return expect(table.createTable()).to.eventually.be.rejected;
@@ -42,6 +66,10 @@ describe('sqlutil', () => {
         .deep.equal({wasCreated: false});
     });
 
+    it('should be possible to update an existing table', () => {
+      return expect(table.createOrUpdateTable()).to.eventually
+        .deep.equal({wasCreated: false, wasUpdated: false});
+    });
 
     it('should reject creating tables with unknown data types', () => {
       let badTable = new sqlutil.Table(db, {
@@ -52,28 +80,26 @@ describe('sqlutil', () => {
         }
       });
 
-      return assert.isRejected(badTable.createTable());
+      return expect(badTable.createTable()).to.eventually.be.rejected;
     });
 
     it('should be possible to add rows to the table', () => {
-      return table.insert({name: 'key1', value: 42})
-        .then(() => {
-          return table.insert({name: 'key2', value: 42});
-        }).then(() => {
-          return table.insert({name: 'key3', value: 43});
-        });
+      return insertSomeData();
     });
 
     it('should be possible to count number of rows in a table', () => {
-      return expect(table.find().count()).to.eventually.equal(3);
+      return insertSomeData()
+        .then(() => expect(table.find().count()).to.eventually.equal(3));
     });
 
     it('should be possible to count number of rows from a query', () => {
-      return expect(table.find({name: 'key1'}).count()).to.eventually.equal(1);
+      return insertSomeData()
+        .then(() => expect(table.find({name: 'key1'}).count()).to.eventually.equal(1));
     });
 
     it('should be possible to count number of rows from an empty query', () => {
-      return expect(table.find({name: 'non-existing-key'}).count()).to.eventually.equal(0);
+      return insertSomeData()
+        .then(() => expect(table.find({name: 'non-existing-key'}).count()).to.eventually.equal(0));
     });
 
     it('should be possible to have default values for columns', () => {
@@ -192,106 +218,89 @@ describe('sqlutil', () => {
       return expect(indexTable.createTable()).to.eventually.be.rejected;
     });
 
-    it('should be possible to have foreign keys between tables', () => {
-      return db.enableForeignKeys().then(() => {
-        let parentTable = new sqlutil.Table(db, {
-          name: 'parent',
-          columns: {
-            id: {type: sqlutil.DataType.INTEGER, primaryKey: true},
-            name: {type: sqlutil.DataType.TEXT, unique: true}
-          }
-        });
-
-        let childTable = new sqlutil.Table(db, {
-          name: 'child',
-          columns: {
-            id: {type: sqlutil.DataType.INTEGER, primaryKey: true},
-            value: {type: sqlutil.DataType.TEXT, unique: true},
-            parentId: {type: sqlutil.DataType.INTEGER}
-          },
-          foreignKeys: [
-            {from: 'parentId', references: {parent: 'id'}}
-          ]
-        });
-
-        return Promise.all([
-          parentTable.createTable(),
-          childTable.createTable()
-        ]).then(() => {
-          // Insert a parent value
-          return parentTable.insert({id: 1, name: 'Banan'})
-            .then(() => childTable.insert({parentId: 1, value: 'Apa'}))
-            .then(() => childTable.insert({parentId: 1, value: 'Ape'}));
-        });
-      });
-    });
-
     it('should be possible to retrieve single rows from the table', () => {
-      return table.find({name: 'key1'}).get().then(row => {
-        assert.isObject(row);
-        assert.equal(row.name, 'key1');
-        assert.equal(row.value, 42);
-      });
+      return insertSomeData()
+        .then(() => table.find({name: 'key1'}).get())
+        .then(row => {
+          assert.isObject(row);
+          assert.equal(row.name, 'key1');
+          assert.equal(row.value, 42);
+        });
     });
 
     it('should be possible to retrieve multiple rows from the table', () => {
-      return table.find({value: 42}).all().then(rows => {
-        assert.isArray(rows);
-        assert.equal(rows.length, 2);
-        assert.equal(rows[0].name, 'key1');
-        assert.equal(rows[1].name, 'key2');
-      });
+      return insertSomeData()
+        .then(() => table.find({value: 42}).all())
+        .then(rows => {
+          assert.isArray(rows);
+          assert.equal(rows.length, 2);
+          assert.equal(rows[0].name, 'key1');
+          assert.equal(rows[1].name, 'key2');
+        });
     });
 
     it('should be possible to order the result rows without specifying order (default is ascending)', () => {
-      return table.find({value: 42}).orderBy(['name']).all().then(rows => {
-        assert.isArray(rows);
-        assert.equal(rows.length, 2);
-        assert.equal(rows[0].name, 'key1');
-        assert.equal(rows[1].name, 'key2');
-      });
+      return insertSomeData()
+        .then(() => table.find({value: 42}).orderBy(['name']).all())
+        .then(rows => {
+          assert.isArray(rows);
+          assert.equal(rows.length, 2);
+          assert.equal(rows[0].name, 'key1');
+          assert.equal(rows[1].name, 'key2');
+        });
     });
 
     it('should be possible to order the result rows ascending', () => {
-      return table.find({value: 42}).orderBy([{name: 1}]).all().then(rows => {
-        assert.isArray(rows);
-        assert.equal(rows.length, 2);
-        assert.equal(rows[0].name, 'key1');
-        assert.equal(rows[1].name, 'key2');
-      });
+      return insertSomeData()
+        .then(() => table.find({value: 42}).orderBy([{name: 1}]).all())
+        .then(rows => {
+          assert.isArray(rows);
+          assert.equal(rows.length, 2);
+          assert.equal(rows[0].name, 'key1');
+          assert.equal(rows[1].name, 'key2');
+        });
     });
 
     it('should be possible to order the result rows descending', () => {
-      return table.find({value: 42}).orderBy([{name: -1}]).all().then(rows => {
-        assert.isArray(rows);
-        assert.equal(rows.length, 2);
-        assert.equal(rows[0].name, 'key2');
-        assert.equal(rows[1].name, 'key1');
-      });
+      return insertSomeData()
+        .then(() => table.find({value: 42}).orderBy([{name: -1}]).all())
+        .then(rows => {
+          assert.isArray(rows);
+          assert.equal(rows.length, 2);
+          assert.equal(rows[0].name, 'key2');
+          assert.equal(rows[1].name, 'key1');
+        });
     });
 
     it('should be possible to limit number of rows retreived', () => {
-      return table.find({value: 42}).limit(1).all().then(rows => {
-        assert.isArray(rows);
-        assert.equal(rows.length, 1);
-        assert.equal(rows[0].name, 'key1');
-      });
+      return insertSomeData()
+        .then(() => table.find({value: 42}).limit(1).all())
+        .then(rows => {
+          assert.isArray(rows);
+          assert.equal(rows.length, 1);
+          assert.equal(rows[0].name, 'key1');
+        });
     });
 
     it('should be possible to iterate over rows from the table', () => {
-      let rowCount = 0;
-      return table.find({value: 42}).each(row => {
-        rowCount++;
-        assert(row.name === 'key1' || row.name === 'key2');
-      }).then(() => {
-        assert.equal(rowCount, 2);
-      });
+      return insertSomeData()
+        .then(() => {
+          let rowCount = 0;
+          return table.find({value: 42}).each(row => {
+            rowCount++;
+            assert(row.name === 'key1' || row.name === 'key2');
+          }).then(() => {
+            assert.equal(rowCount, 2);
+          });
+        });
     });
 
     it('should be possible to stream rows from the table', () => {
-      let sqlStream = table.find({value: 42}).stream();
-
-      assert.eventually.lengthOf(streamutil.streamToArray(sqlStream), 2);
+      let sqlStream = insertSomeData()
+          .then(() => {
+            table.find({value: 42}).stream();
+            return assert.eventually.lengthOf(streamutil.streamToArray(sqlStream), 2);
+          });
     });
 
     it('should be possible to stream rows into a table', () => {
@@ -312,55 +321,65 @@ describe('sqlutil', () => {
     });
 
     it('should be possible to lookup unique fields with a stream', () => {
-      let sourceStream = streamutil.arrayToStream([
-        {name: 'key5'},
-        {name: 'key6'},
-        {name: 'key7', value: 1}, // Will override value from the table
-        {name: 'key8'} // does not exist
-      ]);
+      return insertSomeData()
+        .then(() => table.insert({name: 'key5', value: 62}))
+        .then(() => table.insert({name: 'key6', value: 63}))
+        .then(() => table.insert({name: 'key7', value: 64}))
+        .then(() => {
+          let sourceStream = streamutil.arrayToStream([
+            {name: 'key5'},
+            {name: 'key6'},
+            {name: 'key7', value: 1}, // Will override value from the table
+            {name: 'key8'} // does not exist
+          ]);
 
-      let sqlTransform = table.createExtendStream();
+          let sqlTransform = table.createExtendStream();
 
-      return streamutil.streamToArray(streamutil.pipeline([
-        sourceStream,
-        sqlTransform
-      ])).then(rows => {
-        assert.lengthOf(rows, 4);
+          return streamutil.streamToArray(streamutil.pipeline([
+            sourceStream,
+            sqlTransform
+          ])).then(rows => {
+            assert.lengthOf(rows, 4);
 
-        assert.isNumber(rows[0].id);
-        assert.equal(rows[0].name, 'key5');
-        assert.equal(rows[0].value, 62);
+            assert.isNumber(rows[0].id);
+            assert.equal(rows[0].name, 'key5');
+            assert.equal(rows[0].value, 62);
 
-        assert.isNumber(rows[1].id);
-        assert.equal(rows[1].name, 'key6');
-        assert.equal(rows[1].value, 63);
+            assert.isNumber(rows[1].id);
+            assert.equal(rows[1].name, 'key6');
+            assert.equal(rows[1].value, 63);
 
-        assert.isNumber(rows[2].id);
-        assert.equal(rows[2].name, 'key7');
-        assert.equal(rows[2].value, 1); // overridden value
+            assert.isNumber(rows[2].id);
+            assert.equal(rows[2].name, 'key7');
+            assert.equal(rows[2].value, 1); // overridden value
 
-        assert.isUndefined(rows[3].id);
-        assert.equal(rows[3].name, 'key8');
-        assert.isUndefined(rows[3].value);
-      });
+            assert.isUndefined(rows[3].id);
+            assert.equal(rows[3].name, 'key8');
+            assert.isUndefined(rows[3].value);
+          });
+        });
     });
 
     it('should be possible to select using multiple matchers', () => {
-      return table.find({
-        name: 'key1',
-        value: 42
-      }).get().then(row => {
-        assert.isObject(row);
-        assert.equal(row.name, 'key1');
-        assert.equal(row.value, 42);
-      });
+      return insertSomeData()
+        .then(() => table.find({
+          name: 'key1',
+          value: 42
+        }).get())
+        .then(row => {
+          assert.isObject(row);
+          assert.equal(row.name, 'key1');
+          assert.equal(row.value, 42);
+        });
     });
 
     it('should be possible to select using multiple matchers as separate find calls', () => {
-      return table
-        .find({name: 'key1'})
-        .find({value: 42})
-        .get().then(row => {
+      return insertSomeData()
+        .then(() => table
+              .find({name: 'key1'})
+              .find({value: 42})
+              .get())
+        .then(row => {
           assert.isObject(row);
           assert.equal(row.name, 'key1');
           assert.equal(row.value, 42);
@@ -369,98 +388,110 @@ describe('sqlutil', () => {
 
     it('should be possible select using binary operators', () => {
       let rowCount = 0;
-      return table.find({value: {$le: 42}}).each(row => {
-        rowCount++;
-        assert.isObject(row);
-        assert(row.name === 'key1' || row.name === 'key2');
-      }).then(() => {
-        assert.equal(rowCount, 2);
-      });
+      return insertSomeData()
+        .then(() => table.find({value: {$le: 42}}).each(row => {
+          rowCount++;
+          assert.isObject(row);
+          assert(row.name === 'key1' || row.name === 'key2');
+        })).then(() => {
+          assert.equal(rowCount, 2);
+        });
     });
 
 
     it('should be possible to select using explicit $and', () => {
-      return table.find({$and: [
-        {name: 'key1'},
-        {value: 42}
-      ]}).get().then(row => {
-        assert.equal(row.name, 'key1');
-        assert.equal(row.value, 42);
-      });
+      return insertSomeData()
+        .then(() => table.find({$and: [
+          {name: 'key1'},
+          {value: 42}
+        ]}).get())
+        .then(row => {
+          assert.equal(row.name, 'key1');
+          assert.equal(row.value, 42);
+        });
     });
 
     it('should not be possible to retrieve non-existing rows', () => {
-      return table.find({name: 'non-existing-key'}).get().then(row => {
-        assert.isUndefined(row);
-      });
+      return insertSomeData()
+        .then(() => table.find({name: 'non-existing-key'}).get())
+        .then(row => {
+          assert.isUndefined(row);
+        });
     });
 
     it('should be possible to update rows', () => {
-      return expect(table.insertUpdateUnique({name: 'key1', value: 50}))
-        .to.eventually.deep.equal({
-          id: 1,
-          name: 'key1',
-          value: 50
-        });
+      return insertSomeData()
+        .then(() => expect(table.insertUpdateUnique({name: 'key1', value: 50}))
+              .to.eventually.deep.equal({
+                id: 1,
+                name: 'key1',
+                value: 50
+              }));
     });
 
     it('should be possible to update rows with null values', () => {
-      return expect(table.insertUpdateUnique({name: 'key1', value: null}))
-        .to.eventually.deep.equal({
-          id: 1,
-          name: 'key1',
-          value: null
-        });
+      return insertSomeData()
+        .then(() => expect(table.insertUpdateUnique({name: 'key1', value: null}))
+              .to.eventually.deep.equal({
+                id: 1,
+                name: 'key1',
+                value: null
+              }));
     });
 
     it('should be possible to create unique rows', () => {
-      return table.insertUpdateUnique({name: 'new-unique-key', value: 33}).then(row => {
-        expect(row).to.deep.equal({
-          id: 7,
+      return insertSomeData()
+        .then(() => table.insertUpdateUnique({
           name: 'new-unique-key',
           value: 33
-        });
+        }))
+        .then(row => {
+          expect(row).to.deep.equal({
+            id: 4,
+            name: 'new-unique-key',
+            value: 33
+          });
 
-        // Update the row
-        return expect(table.insertUpdateUnique({
-          id: row.id,
-          value: 34
-        })).to.eventually.deep.equal({
-          id: row.id,
-          name: 'new-unique-key',
-          value: 34
+          // Update the row
+          return expect(table.insertUpdateUnique({
+            id: row.id,
+            value: 34
+          })).to.eventually.deep.equal({
+            id: row.id,
+            name: 'new-unique-key',
+            value: 34
+          });
         });
-      });
     });
 
     it('should be possible to delete rows', () => {
-      return table.find({name: 'key1'}).remove().then(() => {
-        return table.find({name: 'key1'}).get();
-      }).then(row => {
-        assert.isUndefined(row);
-
-        // Restore the table
-        return table.insert({name: 'key1', value: 42});
-      });
+      return insertSomeData()
+        .then(() => table.find({name: 'key1'}).remove())
+        .then(() => table.find({name: 'key1'}).get())
+        .then(row => {
+          assert.isUndefined(row);
+        });
     });
 
     it('should be possible to create a table multiple times with createTableIfNotExists', () => {
-      return table.createTableIfNotExists().then(() => {
-        // Verify that old data still remains
-        return expect(table.find({name: 'key1'}).get())
-          .to.eventually.deep.equal({
-            id: 8,
-            name: 'key1',
-            value: 42
-          });
-      });
+      return insertSomeData()
+        .then(() => table.createTableIfNotExists())
+        .then(() => {
+          // Verify that old data still remains
+          return expect(table.find({name: 'key1'}).get())
+            .to.eventually.deep.equal({
+              id: 1,
+              name: 'key1',
+              value: 42
+            });
+        });
     });
 
     it('should give an error to create a table that already exists', () => {
       return expect(table.createTable()).to.eventually.be.rejected;
     });
 
-    it('should not be possible to add columns to the table', () => {
+    it('should be possible to add columns to the table', () => {
       let newTable = new sqlutil.Table(db, {
         name: 'testtable', // same name as before
         columns: {
@@ -471,19 +502,26 @@ describe('sqlutil', () => {
         }
       });
 
-      return expect(newTable.createTableIfNotExists()).to.eventually.be.rejected;
+      return insertSomeData()
+        .then(() => expect(newTable.createOrUpdateTable()).to.eventually.deep.equal({wasCreated: false, wasUpdated: true}))
+        .then(() => expect(newTable.find({name: 'key3'}).get()).to.eventually.deep.equal({id: 3, name: 'key3', value: 43, value2: 3}));
     });
 
-    it('should not be possible to remove columns from the table', () => {
+    it('should be possible to remove columns from the table', () => {
       let newTable = new sqlutil.Table(db, {
         name: 'testtable', // same name as before
         columns: {
           id: {type: sqlutil.DataType.INTEGER, primaryKey: true},
           name: {type: sqlutil.DataType.TEXT, unique: true}
+          // Removed column "value"
         }
       });
 
-      return expect(newTable.createTableIfNotExists()).to.eventually.be.rejected;
+      return insertSomeData()
+        .then(() => expect(newTable.createOrUpdateTable())
+                           .to.eventually.deep.equal({wasCreated: false, wasUpdated: true}))
+        .then(() => expect(newTable.find({name: 'key3'}).get())
+                           .to.eventually.deep.equal({id: 3, name: 'key3'}));
     });
   });
 

--- a/test/sqlutil.js
+++ b/test/sqlutil.js
@@ -296,9 +296,9 @@ describe('sqlutil', () => {
     });
 
     it('should be possible to stream rows from the table', () => {
-      let sqlStream = insertSomeData()
+      return insertSomeData()
           .then(() => {
-            table.find({value: 42}).stream();
+            let sqlStream = table.find({value: 42}).stream();
             return assert.eventually.lengthOf(streamutil.streamToArray(sqlStream), 2);
           });
     });
@@ -317,7 +317,13 @@ describe('sqlutil', () => {
         sqlWriter
       ]);
 
-      return streamutil.waitForStream(sqlPipeline);
+      return streamutil.waitForStream(sqlPipeline)
+        .then(() => expect(table.find().orderBy(['name']).all())
+              .to.eventually.deep.equal([
+                {id: 1, name: 'key5', value: 62},
+                {id: 2, name: 'key6', value: 63},
+                {id: 3, name: 'key7', value: 64}
+              ]));
     });
 
     it('should be possible to lookup unique fields with a stream', () => {


### PR DESCRIPTION
Make it possible to update tables with foreign keys in a safe way. Now we use transactions for updating tables.